### PR TITLE
Added verify set for SQL

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -5,7 +5,9 @@ go 1.13
 require (
 	github.com/codenotary/immudb v1.1.1-0.20211027130630-7d162c01b780
 	github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00 // indirect
+	github.com/jmoiron/sqlx v1.3.4
 	github.com/kr/text v0.2.0 // indirect
+	github.com/luna-duclos/instrumentedsql v1.1.3
 	github.com/smartystreets/assertions v1.2.0 // indirect
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
 	golang.org/x/net v0.0.0-20211029224645-99673261e6eb // indirect

--- a/go/sql_verify_set.go
+++ b/go/sql_verify_set.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"github.com/codenotary/immudb/pkg/api/schema"
+	immuclient "github.com/codenotary/immudb/pkg/client"
+	"github.com/codenotary/immudb/pkg/stdlib"
+	"github.com/jmoiron/sqlx"
+	"github.com/luna-duclos/instrumentedsql"
+	"log"
+)
+
+func verifySet() {
+
+	// we need both the client as well as a SQL interface
+	client, err := immuclient.NewImmuClient(immuclient.DefaultOptions())
+	if err != nil {
+		log.Fatal(err)
+	}
+	_, err = client.Login(context.TODO(), []byte(`immudb`), []byte(`immudb`))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Bonus: Here's how you instrument SQLX
+	logger := instrumentedsql.LoggerFunc(func(ctx context.Context, msg string, keyvals ...interface{}) {
+		log.Printf("%s %v", msg, keyvals)
+	})
+
+	// Register the new driver as a wrapper of the standard immudb driver
+	sql.Register("instrumented-immudb", instrumentedsql.WrapDriver(&stdlib.Driver{}, instrumentedsql.WithLogger(logger)))
+
+	db, err := sqlx.Open("instrumented-immudb", "immudb://immudb:immudb@127.0.0.1:3322/defaultdb?sslmode=disable")
+	if err != nil {
+		log.Fatal("failed to open DB", err)
+	}
+
+	// Create our test table
+	_, err = client.SQLExec(context.TODO(), `
+CREATE TABLE IF NOT EXISTS healthchecks_two
+(
+    id INTEGER AUTO_INCREMENT,
+    name VARCHAR,
+    was_successful boolean NOT NULL,
+    PRIMARY KEY (id)
+)`, map[string]interface{}{})
+
+	// Insert Data with PGX
+	sqlResult := db.MustExec(`
+	INSERT INTO healthchecks_two (name, was_successful) VALUES ($1, $2, $3)`, "Austin", true)
+
+	// PGX gives us the the Last ID, we'll use this to verify our transaction below
+	lastId, err := sqlResult.LastInsertId()
+	if err != nil {
+		log.Fatal(err, " - last insert ID")
+	}
+
+	// From here, we're going to construct the arguments for the client.VerifyRow method
+	// We'll need
+	// 1. The column names - you can get these by querying the data as shown below
+	// 	queryResult, err := client.SQLQuery(context.TODO(), `SELECT * FROM healthchecks_two WHERE id = @id`, map[string]interface{}{"id": lastId}, true)
+	// 2. The Values we expect to be found in the column with the specified primary key, in the []*schema.SQLValue type
+	// 3. The primary key stored as []*schema.SQLValue
+
+	verifyRow := &schema.Row{
+		// Here are the column names, as a reminder you can get these out of a queryResult
+		Columns: []string{
+			"(defaultdb.healthchecks_two.id)",
+			"(defaultdb.healthchecks_two.name)",
+			"(defaultdb.healthchecks_two.was_successful)",
+		},
+		// The values we are expecting to find
+		Values: []*schema.SQLValue{
+			{
+				Value: &schema.SQLValue_N{
+					N: lastId,
+				},
+			},
+			{
+				Value: &schema.SQLValue_S{
+					S: "Austin",
+				},
+			},
+			{
+				Value: &schema.SQLValue_B{
+					B: true,
+				},
+			},
+		},
+	}
+
+	// The Primary Key
+	PK := []*schema.SQLValue{
+		{
+			Value: &schema.SQLValue_N{
+				N: lastId,
+			},
+		},
+	}
+
+	// Verify the row
+	err = client.VerifyRow(context.TODO(), verifyRow, "healthchecks_two", PK)
+	if err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
It is possible to execute a "Verify Set" for SQL with a little extra jumping through hoops. This does not require any re-querying of data.

For convenience of others, I:
- Set up the popular SQLX library
- Added an SQL logger
- Included a create table command so this would be fast to copy and paste